### PR TITLE
add dreprecated retain alias : interval

### DIFF
--- a/check_rsnapshot.php
+++ b/check_rsnapshot.php
@@ -735,6 +735,7 @@ function parseConfig( $confFile, $primary = true )
                 break;
 
             case "retain":
+            case "interval":
                 _log( sprintf( "PARSING CONF: found retention period: %s => %s", $tokens[1], $tokens[2] ), LOG__DEBUG );
                 $cmdargs["retain"][ $tokens[1] ] = $tokens[2];
                 break;


### PR DESCRIPTION
The interval directive is deprecated but still used in older config files.

From rsnapshot documentation :

> retain [name] [number]
> 
> "name'' refers to the name of this backup level (e.g., hourly, daily, so also called the 'interval'). `number'' is the > number of snapshots for this type of interval that will be retained. The value of`name'' will be the command > passed to rsnapshot to perform this type of backup.
> 
> A deprecated alias for 'retain' is 'interval'. 
