### PR TITLE
check_chassis_brocade.pl: add --perf option

### DIFF
--- a/check_chassis_brocade.pl
+++ b/check_chassis_brocade.pl
@@ -212,18 +212,20 @@ if( $state eq 'OK' )
     print $fandata if( defined( $fandata ) && !$skipfans );
     print $psudata if( defined( $psudata ) && !$skippsu );
     printf( "Up %0.2f days", $uptime ) if( !$skipreboot );
-    if ($perf) {
-        print "|";
-        print $cpudataperf if( !$skipcpuall && defined( $cpudataperf ) );
-        print $memdataperf if( !$skipmem && defined( $memdataperf ) );
-        print $tempdataperf if( !$skiptemp && defined( $tempdataperf ) );
-    }
-    print( "\n" );
 }
 else
 {
-    print "$answer\n";
+    print "$answer";
 }
+
+if ($perf) {
+    print "|";
+    print $cpudataperf if( !$skipcpuall && defined( $cpudataperf ) );
+    print $memdataperf if( !$skipmem && defined( $memdataperf ) );
+    print $tempdataperf if( !$skiptemp && defined( $tempdataperf ) );
+}
+
+print( "\n" );
 
 exit $ERRORS{$state};
 


### PR DESCRIPTION
Add --perf option to produce performance data output
Output example:
OK - CPU: 1min 1% 5sec 1% 1sec 1%. Memory OK (6%). Temp (A/W/C): 48.5/85.0/90.0; Fans: OK OK. PSUs: OK N/A. Up 25.91 days|CPU_1min=1%;70;90 CPU_5sec=1%;85;95 CPU_1sec=1%;95;98 Memory=6%;70;90 Temp=48.5deg;85.0;90.0
