### PR TITLE
Update check_arista_chassis_api.php - memFree incorrect

### DIFF
--- a/check_arista_chassis_api.php
+++ b/check_arista_chassis_api.php
@@ -380,7 +380,7 @@ function checkMemory( $mem )
     if( isset( $cmdargs['skip-mem'] ) && $cmdargs['skip-mem'] )
         return;
 
-    $memUtil = sprintf( "%0.2f", ( $mem->memFree / $mem->memTotal ) * 100.0 );
+    $memUtil = sprintf( "%0.2f", (1 - $mem->memFree / $mem->memTotal ) * 100.0 );
 
     if( $memUtil > $cmdargs['memcrit'] ) {
         setStatus( STATUS_CRITICAL );


### PR DESCRIPTION
Discovered the checkMemory function was actually returning the percentage memory FREE not USED.

We got some new switches with so much RAM they start with 62G out of 64G free, and they alarmed as they had over 90% free memory. 🙃